### PR TITLE
Экспортируемый MoneyText 

### DIFF
--- a/src/00atoms/RubleIcon.js
+++ b/src/00atoms/RubleIcon.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import {Icon} from "react-native-elements";
+import {TextStyles} from '../styles/Base';
+import {moderateScale} from "../styles/Scaling";
+import PropTypes from "prop-types";
+
+export default class RubleIcon extends React.Component {
+  static propTypes = {
+    rubleSize: PropTypes.number
+  };
+  static defaultProps = {
+    rubleSize: 24
+  };
+  
+  render(){
+    return(
+      <Icon
+        iconStyle={[TextStyles.moneyIcon, {fontSize: moderateScale(this.props.rubleSize)}]}
+        name="ruble"
+        type="font-awesome"
+      />
+    );
+  }
+}

--- a/src/00atoms/RubleIcon.js
+++ b/src/00atoms/RubleIcon.js
@@ -1,21 +1,23 @@
 import React from 'react';
 import {Icon} from "react-native-elements";
-import {TextStyles} from '../styles/Base';
+import {COLORS, TextStyles} from '../styles/Base';
 import {moderateScale} from "../styles/Scaling";
 import PropTypes from "prop-types";
 
 export default class RubleIcon extends React.Component {
   static propTypes = {
-    rubleSize: PropTypes.number
+    rubleSize: PropTypes.number,
+    color: PropTypes.string
   };
   static defaultProps = {
-    rubleSize: 24
+    rubleSize: 24,
+    color: COLORS.WHITE
   };
   
   render(){
     return(
       <Icon
-        iconStyle={[TextStyles.moneyIcon, {fontSize: moderateScale(this.props.rubleSize)}]}
+        iconStyle={[TextStyles.moneyIcon, {color: this.props.color, fontSize: moderateScale(this.props.rubleSize)}]}
         name="ruble"
         type="font-awesome"
       />

--- a/src/01molecules/BalanceCircle.js
+++ b/src/01molecules/BalanceCircle.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import {Text, TouchableOpacity, View, Platform} from 'react-native';
 import PropTypes from 'prop-types';
 import {CircleStyles, TextStyles} from '../styles/Base';
-import MoneyText from '../00atoms/MoneyText';
+import MoneyText from './MoneyText';
 import {moderateScale, baseRadius, getCircleDiagonal} from "../styles/Scaling";
 
 export default class BalanceCircle extends React.Component {

--- a/src/01molecules/MoneyText.js
+++ b/src/01molecules/MoneyText.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {View} from 'react-native';
-import {TextStyles} from '../styles/Base';
+import {COLORS, TextStyles} from '../styles/Base';
 import {moderateScale} from "../styles/Scaling";
 import PropTypes from "prop-types";
 import SimpleText from '../00atoms/SimpleText';
@@ -13,12 +13,14 @@ export default class MoneyText extends React.Component {
       PropTypes.number
     ]),
     rubleSize: PropTypes.number,
-    centSize: PropTypes.number
+    centSize: PropTypes.number,
+    color: PropTypes.string
   };
   static defaultProps = {
     moneySumm: null,
     rubleSize: 24,
-    centSize: 14
+    centSize: 14,
+    color: COLORS.WHITE
   };
 
   formatCurrencyDot = (value) => {
@@ -55,14 +57,18 @@ export default class MoneyText extends React.Component {
           accessible={false}
           style={TextStyles.moneyText}
         >
-          <SimpleText style={[TextStyles.moneyRubles, {fontSize: moderateScale(this.props.rubleSize)}]}>
+          <SimpleText
+            style={[TextStyles.moneyRubles, {color: this.props.color, fontSize: moderateScale(this.props.rubleSize)}]}>
             {rubles}
             {","}
           </SimpleText>
-          <SimpleText style={[TextStyles.moneyCents, {fontSize: moderateScale(this.props.centSize)}]}>
+          <SimpleText
+            style={[TextStyles.moneyCents, {color: this.props.color, fontSize: moderateScale(this.props.centSize)}]}>
             {currencyText[1]}
           </SimpleText>
-            <RubleIcon rubleSize={this.props.rubleSize}/>
+            <RubleIcon
+              color={this.props.color}
+              rubleSize={this.props.rubleSize}/>
         </View>
     );
   }

--- a/src/01molecules/MoneyText.js
+++ b/src/01molecules/MoneyText.js
@@ -1,18 +1,24 @@
 import React from 'react';
-import {Text, View} from 'react-native';
+import {View} from 'react-native';
 import {TextStyles} from '../styles/Base';
+import {moderateScale} from "../styles/Scaling";
 import PropTypes from "prop-types";
-import {Icon} from "react-native-elements";
+import SimpleText from '../00atoms/SimpleText';
+import RubleIcon from '../00atoms/RubleIcon';
 
 export default class MoneyText extends React.Component {
   static propTypes = {
     moneySumm: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.number
-    ])
+    ]),
+    rubleSize: PropTypes.number,
+    centSize: PropTypes.number
   };
   static defaultProps = {
-    moneySumm: null
+    moneySumm: null,
+    rubleSize: 24,
+    centSize: 14
   };
 
   formatCurrencyDot = (value) => {
@@ -49,24 +55,14 @@ export default class MoneyText extends React.Component {
           accessible={false}
           style={TextStyles.moneyText}
         >
-            <Text
-              allowFontScaling={false}
-              style={TextStyles.moneyRubles}
-            >
-                {rubles}
-                {","}
-            </Text>
-            <Text
-              allowFontScaling={false}
-              style={TextStyles.moneyCents}
-            >
-                {currencyText[1]}
-            </Text>
-            <Icon
-              iconStyle={TextStyles.moneyIcon}
-              name="ruble"
-              type="font-awesome"
-            />
+          <SimpleText style={[TextStyles.moneyRubles, {fontSize: moderateScale(this.props.rubleSize)}]}>
+            {rubles}
+            {","}
+          </SimpleText>
+          <SimpleText style={[TextStyles.moneyCents, {fontSize: moderateScale(this.props.centSize)}]}>
+            {currencyText[1]}
+          </SimpleText>
+            <RubleIcon rubleSize={this.props.rubleSize}/>
         </View>
     );
   }

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,8 @@ import Button, {BUTTON_TYPES} from './01molecules/Button';
 import PairCircles from './02organisms/PairCircles';
 import Search from './01molecules/Search';
 import MenuItem from './01molecules/MenuItem';
-import MoneyText from './00atoms/MoneyText';
+import MoneyText from './01molecules/MoneyText';
+import RubleIcon from './00atoms/RubleIcon';
 
 export {
     COLORS,
@@ -24,5 +25,6 @@ export {
     PairCircles,
     Search,
     MenuItem,
-    MoneyText
+    MoneyText,
+    RubleIcon
 };

--- a/src/styles/Base.js
+++ b/src/styles/Base.js
@@ -52,19 +52,16 @@ export const TextStyles = StyleSheet.create({
   },
   moneyRubles: {
     fontFamily: "Arial",
-    color: COLORS.WHITE,
     fontWeight: "bold",
   },
   moneyCents: {
     fontFamily: "Arial",
-    color: COLORS.WHITE,
     marginLeft: scale(3),
     marginBottom: scale(3),
     marginRight: scale(6),
     fontWeight: "bold",
   },
   moneyIcon: {
-    color: COLORS.WHITE,
     marginBottom: scale(3),
   },
   networkTitle: {

--- a/src/styles/Base.js
+++ b/src/styles/Base.js
@@ -53,13 +53,11 @@ export const TextStyles = StyleSheet.create({
   moneyRubles: {
     fontFamily: "Arial",
     color: COLORS.WHITE,
-    fontSize: moderateScale(24),
     fontWeight: "bold",
   },
   moneyCents: {
     fontFamily: "Arial",
     color: COLORS.WHITE,
-    fontSize: moderateScale(14),
     marginLeft: scale(3),
     marginBottom: scale(3),
     marginRight: scale(6),
@@ -68,7 +66,6 @@ export const TextStyles = StyleSheet.create({
   moneyIcon: {
     color: COLORS.WHITE,
     marginBottom: scale(3),
-    fontSize: moderateScale(24)
   },
   networkTitle: {
     color: COLORS.WHITE,


### PR DESCRIPTION
Заменил `<Text>` на `<SimpleText>` из атомов, добавил атом иконки Рубля, сделал настраиваемый размер MoneyText

![Снимок экрана от 2019-06-13 16-14-05](https://user-images.githubusercontent.com/46071900/59428319-550e9100-8df6-11e9-9814-3a3dd5157e89.png)
![Снимок экрана от 2019-06-13 16-14-20](https://user-images.githubusercontent.com/46071900/59428320-55a72780-8df6-11e9-98a4-cdae561beeb0.png)
![Снимок экрана от 2019-06-13 16-15-26](https://user-images.githubusercontent.com/46071900/59428383-7a9b9a80-8df6-11e9-8164-63a78083dd6a.png)

